### PR TITLE
fix: remove format extension for public-id

### DIFF
--- a/packages/url/__tests__/url.test.ts
+++ b/packages/url/__tests__/url.test.ts
@@ -80,7 +80,7 @@ describe('Url', () => {
         forceVersion: true,
       })).toEqual('')
     });
-    
+
     it('should not force a version when it already contains a version ', () => {
       expect(getVersion('v3/a', {
         forceVersion: true,
@@ -95,10 +95,6 @@ describe('Url', () => {
 
     it('should return public id without extension and suffix', () => {
       expect(getPathToAsset('example', {})).toBe('example')
-    })
-
-    it('should return publicid path with new extension', () => {
-      expect(getPathToAsset('example.gif', { format: '.jpg' })).toBe('example.jpg')
     })
 
     it('should return publicId with suffix', () => {
@@ -130,7 +126,7 @@ describe('Url', () => {
       expect(url('example', {
         cloudName: 'demo',
         forceVersion: true
-      }, {        
+      }, {
         resize: {
           width: 500,
           type: 'scale',

--- a/packages/url/lib/url.ts
+++ b/packages/url/lib/url.ts
@@ -14,7 +14,7 @@ export const extractPublicId = (link: string):string => {
   const parts = CLOUDINARY_REGEX.exec(link)
 
   return parts && parts.length > 2 ? parts[parts.length - 2] : link
-} 
+}
 
 export const getSignature = (signature?: string) => {
   if (!signature) return ''
@@ -42,13 +42,13 @@ export const getSubDomain = (publicId: string, { cdnSubdomain = false, cname } :
   return cdnSubdomain ? `a${publicId}.` : ''
 }
 
-export const getPrefix = (publicId: string, { 
-  cloudName, 
-  privateCdn = false, 
-  cdnSubdomain = false, 
-  secureDistribution, 
-  cname, 
-  secure = true, 
+export const getPrefix = (publicId: string, {
+  cloudName,
+  privateCdn = false,
+  cdnSubdomain = false,
+  secureDistribution,
+  cname,
+  secure = true,
 }: CloudConfig):string => {
   const hasSecureDistribution = secure && secureDistribution && !SHARED_CDNS.includes(secureDistribution)
   const protocol = `http${secure ? 's' : ''}://`
@@ -95,11 +95,10 @@ export const getResourceType = ({
 
 const isUrl = (str) => str && !!str.match(/^https?:\//)
 
-export const getPathToAsset = (publicId: string, { urlSuffix = '', format = '' } : { urlSuffix?: string, format?: string }):string => {
+export const getPathToAsset = (publicId: string, { urlSuffix = '' } : { urlSuffix?: string }):string => {
   if (isUrl(publicId)) return encodePublicId(publicId)
 
-  const publicIdWithFormat = publicId.replace(/\.[^/.]+$/, format || '')
-  const path = [publicIdWithFormat, urlSuffix].filter(Boolean).join('/')
+  const path = [publicId, urlSuffix].filter(Boolean).join('/')
 
   return encodePublicId(path)
 }
@@ -111,7 +110,7 @@ export const url = (publicId: string, cloud: CloudConfig = { cloudName: ''}, opt
 
   //If publicId is cloudinary url, strip to get the publicId and version.
   const _publicId = isUrl(publicId) ? extractPublicId(publicId) : publicId
-  
+
   //1. Get version
   const version:string = getVersion(_publicId, cloud)
   //2. Get Prefix
@@ -121,7 +120,7 @@ export const url = (publicId: string, cloud: CloudConfig = { cloudName: ''}, opt
   //4. Get Resource type
   const typePath:string = getResourceType(cloud)
   //5. Get path
-  const pathToAsset:string = getPathToAsset(_publicId, { format: options.format, urlSuffix: cloud.urlSuffix })
+  const pathToAsset:string = getPathToAsset(_publicId, { urlSuffix: cloud.urlSuffix })
   //6. Encode everything with %20 for whitespace
 
   const format = options.fetchFormat || options.format || 'auto'


### PR DESCRIPTION
#### Resolves
Issue #22, i.e. publicId getting malformed in case it contains "."-char other than as part of extension

#### Technical note
I removed it completely because I think it is not taking effect anyways, due to the explicit "f_[format]" transformation that is applied later on (https://github.com/mayashavin/cloudinary-api/blob/main/packages/url/lib/url.ts#L127)

E.g., If I take the url from the sample 
- https://res.cloudinary.com/adacmkv/image/upload/f_auto,q_auto/v1608641937/ADAC%20Klassik/2021/Events/AEC/RS134993_RS129423_8.1_v7gpvg.jpg 

even with auto-format (aka `f_auto`) this will result in content-type `image/web_p` being downloaded in most modern browsers, despite the `.jpg` extension that is part of the `publicID`.

![image](https://user-images.githubusercontent.com/1517125/121781237-245bc080-cba4-11eb-8f96-c4cc77a03c03.png)

From my understanding the file-extension is only taken under consideration if there is no format-option present, wich will never be the case here?

