### PR TITLE
Update resize values according to cloudinary docs 

### DIFF
--- a/packages/utils/lib/constants/resize.ts
+++ b/packages/utils/lib/constants/resize.ts
@@ -4,13 +4,13 @@ export const RESIZE_TYPES = {
   CROP: 'crop',
   FILL: 'fill',
   SCALE: 'scale',
-  MIN_PAD: 'minimumPad',
+  MIN_PAD: 'mpad',
   FIT: 'fit',
   PAD: 'pad',
-  LIMIT_FIT: 'limitFit',
+  LIMIT_FIT: 'limit',
   THUMBNAIL: 'thumb',
-  LIMIT_FILL: 'limitFill',
-  MIN_FIT: 'minimumFit',
-  LIMIT_PAD: 'limitPad',
-  FILL_PAD: 'fillPad'
+  LIMIT_FILL: 'lfill',
+  MIN_FIT: 'mfit',
+  LIMIT_PAD: 'lpad',
+  FILL_PAD: 'fill_pad'
 } as const


### PR DESCRIPTION
A few values here were not according to the docs and caused errors when using them.
https://cloudinary.com/documentation/transformation_reference#c_crop_resize

Reproduction showing all problematic resize types: https://codesandbox.io/s/blazing-worker-rdm60?file=/src/index.ts