### PR TITLE
Fix truncating urls for paths with multiple dots (#46)

### DIFF
--- a/packages/url/__tests__/url.test.ts
+++ b/packages/url/__tests__/url.test.ts
@@ -209,6 +209,10 @@ describe('Url', () => {
     it('should return as is', () => {
       expect(extractPublicId('example')).toEqual('example')
     })
+
+    it('should allow multiple dots in the filename before the extension', () => {
+      expect(extractPublicId('https://res.cloudinary.com/xyz/image/upload/v111111111/Folder/Name.With.Multiple.Dots.png')).toBe('Folder/Name.With.Multiple.Dots')
+    })
   })
 
   describe('getSubDomain', () => {

--- a/packages/url/__tests__/url.test.ts
+++ b/packages/url/__tests__/url.test.ts
@@ -210,6 +210,10 @@ describe('Url', () => {
       expect(extractPublicId('example')).toEqual('example')
     })
 
+    it('should correctly handle filenames with no extension', () => {
+      expect(extractPublicId('https://res.cloudinary.com/xyz/image/upload/v111111111/Folder/noextension')).toBe('Folder/noextension')
+    })
+
     it('should allow multiple dots in the filename before the extension', () => {
       expect(extractPublicId('https://res.cloudinary.com/xyz/image/upload/v111111111/Folder/Name.With.Multiple.Dots.png')).toBe('Folder/Name.With.Multiple.Dots')
     })

--- a/packages/url/lib/url.ts
+++ b/packages/url/lib/url.ts
@@ -6,14 +6,19 @@ import { toTransformationStr, transform } from './transformers'
 const SHARED_CDNS:string[] = ["cloudinary-a.akamaihd.net", "res.cloudinary.com"]
 
 //eslint-disable-next-line
-const CLOUDINARY_REGEX = /^.+\.cloudinary\.com\/(?:[^\/]+\/)(?:(image|video|raw)\/)?(?:(upload|fetch|private|authenticated|sprite|facebook|twitter|youtube|vimeo)\/)?(?:(?:[^_/]+_[^,/]+,?)*\/)?(?:v(\d+|\w{1,2})\/)?([^\.^\s]+)(?:\.(.+))?$/
+const CLOUDINARY_REGEX = /^.+\.cloudinary\.com\/(?:[^\/]+\/)(?:(image|video|raw)\/)?(?:(upload|fetch|private|authenticated|sprite|facebook|twitter|youtube|vimeo)\/)?(?:(?:[^_/]+_[^,/]+,?)*\/)?(?:v(\d+|\w{1,2})\/)?(.+)$/
 
 export const extractPublicId = (link: string):string => {
   if (!link) return ''
 
   const parts = CLOUDINARY_REGEX.exec(link)
 
-  return parts && parts.length > 2 ? parts[parts.length - 2] : link
+  if (!parts) {
+    return link
+  }
+
+  // Strip extension if present
+  return parts[parts.length - 1].replace(/\.[^/.]+$/, "")
 }
 
 export const getSignature = (signature?: string) => {


### PR DESCRIPTION
Fix for public IDs containing multiple dots before the extension getting truncated. For example, in 0.2.4  `https://res.cloudinary.com/xyz/image/upload/v111111111/Folder/Name.With.Multiple.Dots.png` is extracted as `Folder/Name` instead of `Folder/Name.With.Multiple.Dots`. This fix (maybe incorrectly) assumes everything after the _last_ `.` is an extension, but it does correctly include any dots before the last `.` in the ID so it should work for most cases.

Not sure if it should be more careful about specifically only removing image and video extensions but I thought that might be over-complicating it.

Fixes #46  